### PR TITLE
Switch tick timing to minutes

### DIFF
--- a/game/config.js
+++ b/game/config.js
@@ -2,8 +2,9 @@ export const tileSize = 32;
 export const mapWidth = 20;
 export const mapHeight = 15;
 
-export const tickRate = 100; // ticks per second
-export const tickDuration = 1000 / tickRate; // milliseconds per tick
+export const ticksPerMinute = 100; // ticks per minute
+export const tickRate = ticksPerMinute / 60; // ticks per second
+export const tickDuration = 60000 / ticksPerMinute; // milliseconds per tick
 
 export const backgroundColor = '#0b0f27';
 
@@ -16,7 +17,7 @@ export const resourceColors = {
 
 export const playerColor = '#00ffab';
 
-// Respawn time ranges for resources in ticks (tickRate = 100 ticks per second).
+// Respawn time ranges for resources in ticks (ticksPerMinute = 100).
 export const resourceRespawnTicks = {
   ore: { min: 300, max: 600 },   // 3–6 seconds
   scrap: { min: 200, max: 500 }  // 2–5 seconds

--- a/game/main.js
+++ b/game/main.js
@@ -1,4 +1,4 @@
-import { tileSize, mapWidth, mapHeight, backgroundColor, tickRate } from './config.js';
+import { tileSize, mapWidth, mapHeight, backgroundColor, tickDuration } from './config.js';
 import World from './world.js';
 import Player from './player_osrs.js';
 
@@ -33,7 +33,7 @@ function createGame() {
   setInterval(() => {
     player.update();
     world.tick();
-  }, 1000 / tickRate);
+  }, tickDuration);
 
   requestAnimationFrame(gameLoop);
 }

--- a/game/world.js
+++ b/game/world.js
@@ -1,4 +1,4 @@
-import { tileSize, mapWidth, mapHeight, resourceColors, defaultTileColor, resourceRespawnTicks } from './config.js';
+import { tileSize, mapWidth, mapHeight, resourceColors, defaultTileColor, resourceRespawnTicks, tickRate } from './config.js';
 
 export default class World {
   constructor() {
@@ -88,13 +88,14 @@ export default class World {
     if (tile.type === 'ore' || tile.type === 'scrap') {
       player.xp += 1;
       player.inventory[tile.type] = (player.inventory[tile.type] || 0) + 1;
-      // Set respawn info and clear tile
+      // Set respawn info and clear tile (respawn range is in seconds,
+      // converted to ticks using tickRate)
       tile.respawnType = tile.type;
       tile.respawnTicksRemaining = Math.floor(
         (resourceRespawnTicks[tile.type].min +
           Math.random() *
             (resourceRespawnTicks[tile.type].max -
-              resourceRespawnTicks[tile.type].min)) * 100
+              resourceRespawnTicks[tile.type].min)) * tickRate
       );
       tile.type = 'empty';
       return true;


### PR DESCRIPTION
## Summary
- change tick configuration to `ticksPerMinute`
- reference tick duration in main loop
- compute respawn timers using `tickRate`

## Testing
- `node -e "import('./game/config.js').then(cfg=>console.log(cfg));" --experimental-modules --no-warnings`
- `node -e "import('./game/world.js').then(m=>console.log('world loaded'));" --no-warnings`

------
https://chatgpt.com/codex/tasks/task_e_6887f1fa1438832b81334d8bfd392ea5