### PR TITLE
Expand README for project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # pazneria.github.io
+
+This repository contains the static files for the **Pazneria** website. It is a simple static site composed of HTML, CSS and JavaScript.
+
+The site hosts various small projects and experiments. Notably, under `game/` lives a canvas-based RPG written in JavaScript. You can open `game.html` to play the game directly in your browser.
+
+Older code for the Dataforge idle game has been removed. References remain in some of the page navigation, but the legacy implementation has been cleaned out of the repository.


### PR DESCRIPTION
## Summary
- document Pazneria static site in the README
- highlight the canvas-based RPG under `game/`
- note the removal of older Dataforge code

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6887ef387738832bbf3fb9a699b45a5b