### PR TITLE
Replace Dataforge references with Game

### DIFF
--- a/about.html
+++ b/about.html
@@ -21,7 +21,7 @@
       <ul class="nav-list">
         <li><a href="index.html" class="nav-link">Home</a></li>
         <li><a href="agi.html" class="nav-link">AGI Forecasting</a></li>
-        <li><a href="game.html" class="nav-link">Dataforge Game</a></li>
+        <li><a href="game.html" class="nav-link">Game</a></li>
         <li><a href="about.html" class="nav-link">About</a></li>
         <li><a href="contact.html" class="nav-link">Contact</a></li>
       </ul>

--- a/agi.html
+++ b/agi.html
@@ -77,7 +77,7 @@
       <ul class="nav-list">
         <li><a href="index.html" class="nav-link">Home</a></li>
         <li><a href="agi.html" class="nav-link">AGI Forecasting</a></li>
-        <li><a href="game.html" class="nav-link">Dataforge Game</a></li>
+        <li><a href="game.html" class="nav-link">Game</a></li>
         <li><a href="about.html" class="nav-link">About</a></li>
         <li><a href="contact.html" class="nav-link">Contact</a></li>
       </ul>

--- a/contact.html
+++ b/contact.html
@@ -20,7 +20,7 @@
       <ul class="nav-list">
         <li><a href="index.html" class="nav-link">Home</a></li>
         <li><a href="agi.html" class="nav-link">AGI Forecasting</a></li>
-        <li><a href="game.html" class="nav-link">Dataforge Game</a></li>
+        <li><a href="game.html" class="nav-link">Game</a></li>
         <li><a href="about.html" class="nav-link">About</a></li>
         <li><a href="contact.html" class="nav-link">Contact</a></li>
       </ul>

--- a/game.html
+++ b/game.html
@@ -1,8 +1,7 @@
 <!--
-Pazneria Game – futuristic tile‑based RPG.
-This page replaces the old Dataforge idle game with a custom canvas‑based
-RPG.  The global navigation and site styling remain shared via
-assets/style.css, while game specific styling lives in assets/game.css.
+Pazneria Game – futuristic tile-based RPG.
+This custom canvas-based game shares global navigation and site styling via
+assets/style.css, while its own styling lives in assets/game.css.
 -->
 <!DOCTYPE html>
 <html lang="en">

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       <ul class="nav-list">
         <li><a href="index.html" class="nav-link">Home</a></li>
         <li><a href="agi.html" class="nav-link">AGI Forecasting</a></li>
-        <li><a href="game.html" class="nav-link">Dataforge Game</a></li>
+        <li><a href="game.html" class="nav-link">Game</a></li>
         <li><a href="about.html" class="nav-link">About</a></li>
         <li><a href="contact.html" class="nav-link">Contact</a></li>
       </ul>
@@ -37,7 +37,7 @@
       <p>
         This site is a playground for experiments in AI, computer
         science and interactive art. Explore our AGI forecasting research,
-        play the Dataforge game or browse other projects as they are
+        play the game or browse other projects as they are
         added.
       </p>
     </section>


### PR DESCRIPTION
## Summary
- update nav links to say "Game" instead of "Dataforge Game"
- mention playing "the game" on the homepage
- revise the game page comment to no longer reference the old Dataforge game

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887ef360994832bb251d530a05c5600