### PR TITLE
Fix resource respawn duration

### DIFF
--- a/game/world.js
+++ b/game/world.js
@@ -91,10 +91,10 @@ export default class World {
       // Set respawn info and clear tile
       tile.respawnType = tile.type;
       tile.respawnTicksRemaining = Math.floor(
-        (resourceRespawnTicks[tile.type].min +
+        resourceRespawnTicks[tile.type].min +
           Math.random() *
             (resourceRespawnTicks[tile.type].max -
-              resourceRespawnTicks[tile.type].min)) * 100
+              resourceRespawnTicks[tile.type].min)
       );
       tile.type = 'empty';
       return true;


### PR DESCRIPTION
## Summary
- ensure resource respawn uses configured tick duration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887e9dd2ce0832bb1f72667e12d8123