### PR TITLE
Fix click scaling for game canvas

### DIFF
--- a/game/main.js
+++ b/game/main.js
@@ -24,8 +24,13 @@ function createGame() {
 
   canvas.addEventListener('click', (event) => {
     const rect = canvas.getBoundingClientRect();
-    const pixelX = event.clientX - rect.left;
-    const pixelY = event.clientY - rect.top;
+    // Scale the click position from the displayed size back to the
+    // canvas's internal coordinate system. Without this the player
+    // would walk to the wrong tile when the canvas is stretched by CSS.
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const pixelX = (event.clientX - rect.left) * scaleX;
+    const pixelY = (event.clientY - rect.top) * scaleY;
     const { x, y } = world.getTileCoordinates(pixelX, pixelY);
     player.moveTo(x, y);
   });


### PR DESCRIPTION
## Summary
- ensure clicks are mapped correctly to tiles even when the canvas is scaled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887f64b9428832bb2ef4bbb7b988150