### PR TITLE
Update gathering behavior

### DIFF
--- a/game/config.js
+++ b/game/config.js
@@ -2,6 +2,8 @@ export const tileSize = 32;
 export const mapWidth = 20;
 export const mapHeight = 15;
 
+// Game time is measured exclusively in ticks. 100 ticks per minute means
+// one tick every 600ms.
 export const ticksPerMinute = 100; // ticks per minute
 export const tickRate = ticksPerMinute / 60; // ticks per second
 export const tickDuration = 60000 / ticksPerMinute; // milliseconds per tick

--- a/game/player_osrs.js
+++ b/game/player_osrs.js
@@ -56,12 +56,13 @@ export default class Player {
       this.pixelX = this.x * tileSize + tileSize / 2;
       this.pixelY = this.y * tileSize + tileSize / 2;
     } else {
-      // If reached destination and have gather target, check adjacency
+      // If reached destination and have a gather target, check adjacency and
+      // collect from all surrounding tiles.
       if (this.gatherTarget) {
         const gx = this.gatherTarget.x;
         const gy = this.gatherTarget.y;
         if (Math.abs(gx - this.x) <= 1 && Math.abs(gy - this.y) <= 1) {
-          this.world.gatherResourceAt(gx, gy, this);
+          this.world.gatherAdjacentResources(this.x, this.y, this);
           this.gatherTarget = null;
           this.saveState();
         }

--- a/game/world.js
+++ b/game/world.js
@@ -1,4 +1,4 @@
-import { tileSize, mapWidth, mapHeight, resourceColors, defaultTileColor, resourceRespawnTicks, tickRate } from './config.js';
+import { tileSize, mapWidth, mapHeight, resourceColors, defaultTileColor, resourceRespawnTicks } from './config.js';
 
 export default class World {
   constructor() {
@@ -88,19 +88,36 @@ export default class World {
     if (tile.type === 'ore' || tile.type === 'scrap') {
       player.xp += 1;
       player.inventory[tile.type] = (player.inventory[tile.type] || 0) + 1;
-      // Set respawn info and clear tile (respawn range is in seconds,
-      // converted to ticks using tickRate)
+      // Set respawn info and clear tile. Respawn times are defined in ticks,
+      // so no conversion is needed here.
       tile.respawnType = tile.type;
       tile.respawnTicksRemaining = Math.floor(
-        (resourceRespawnTicks[tile.type].min +
+        resourceRespawnTicks[tile.type].min +
           Math.random() *
             (resourceRespawnTicks[tile.type].max -
-              resourceRespawnTicks[tile.type].min)) * tickRate
+              resourceRespawnTicks[tile.type].min)
       );
       tile.type = 'empty';
       return true;
     }
     return false;
+  }
+
+  // Gather resources from all tiles adjacent (including diagonally) to the
+  // specified center tile. Returns the number of resources gathered.
+  gatherAdjacentResources(cx, cy, player) {
+    let count = 0;
+    for (let dy = -1; dy <= 1; dy++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        if (dx === 0 && dy === 0) continue;
+        const nx = cx + dx;
+        const ny = cy + dy;
+        if (this.gatherResourceAt(nx, ny, player)) {
+          count += 1;
+        }
+      }
+    }
+    return count;
   }
 
   tick() {

--- a/tests/world.test.js
+++ b/tests/world.test.js
@@ -41,3 +41,21 @@ test('gathering a resource respawns after the configured number of ticks', () =>
   assert.equal(tile.respawnType, null, 'respawnType cleared');
   assert.equal(tile.respawnTicksRemaining, 0, 'respawn timer reset');
 });
+
+// Test gathering multiple resources around a center tile
+test('gatherAdjacentResources collects from all neighbouring tiles', () => {
+  const world = new World();
+  const player = createPlayer();
+
+  // Place three resources around (0,0)
+  world.tiles[0][1] = { type: 'ore', respawnType: null, respawnTicksRemaining: 0 };
+  world.tiles[1][0] = { type: 'scrap', respawnType: null, respawnTicksRemaining: 0 };
+  world.tiles[1][1] = { type: 'ore', respawnType: null, respawnTicksRemaining: 0 };
+
+  const count = world.gatherAdjacentResources(0, 0, player);
+
+  assert.equal(count, 3, 'gathered three resources');
+  assert.equal(world.tiles[0][1].type, 'empty');
+  assert.equal(world.tiles[1][0].type, 'empty');
+  assert.equal(world.tiles[1][1].type, 'empty');
+});


### PR DESCRIPTION
## Summary
- clarify that timing is tick-based
- have resources respawn using ticks directly
- add `gatherAdjacentResources` to gather from all neighbouring tiles
- collect from all adjacent tiles once player reaches a target
- test gathering multiple adjacent resources

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688803fe8bb4832ba64ccff6a4463ebc