### PR TITLE
Fix targeted resource gathering

### DIFF
--- a/game/player_osrs.js
+++ b/game/player_osrs.js
@@ -56,13 +56,12 @@ export default class Player {
       this.pixelX = this.x * tileSize + tileSize / 2;
       this.pixelY = this.y * tileSize + tileSize / 2;
     } else {
-      // If reached destination and have a gather target, check adjacency and
-      // collect from all surrounding tiles.
+      // If reached destination and have a gather target, collect only that tile
       if (this.gatherTarget) {
         const gx = this.gatherTarget.x;
         const gy = this.gatherTarget.y;
         if (Math.abs(gx - this.x) <= 1 && Math.abs(gy - this.y) <= 1) {
-          this.world.gatherAdjacentResources(this.x, this.y, this);
+          this.world.gatherResourceAt(gx, gy, this);
           this.gatherTarget = null;
           this.saveState();
         }

--- a/tests/player_osrs.test.js
+++ b/tests/player_osrs.test.js
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import World from '../game/world.js';
+import Player from '../game/player_osrs.js';
+
+function setupWorld() {
+  const world = new World();
+  // Clear map and place two resources next to player start
+  for (let y = 0; y < world.height; y++) {
+    for (let x = 0; x < world.width; x++) {
+      world.tiles[y][x].type = 'empty';
+    }
+  }
+  world.tiles[0][1] = { type: 'ore', respawnType: null, respawnTicksRemaining: 0 };
+  world.tiles[1][1] = { type: 'scrap', respawnType: null, respawnTicksRemaining: 0 };
+  return world;
+}
+
+test('player gathers only the targeted resource', () => {
+  globalThis.localStorage = {
+    getItem() { return null; },
+    setItem() {}
+  };
+  const world = setupWorld();
+  const player = new Player(world, 0, 0);
+
+  // Target the ore at (1,0)
+  player.gatherTarget = { x: 1, y: 0 };
+  player.update();
+
+  assert.equal(world.tiles[0][1].type, 'empty');
+  assert.equal(world.tiles[1][1].type, 'scrap');
+  assert.equal(player.inventory.ore, 1);
+  assert.ok(!player.inventory.scrap);
+});


### PR DESCRIPTION
## Summary
- only gather the resource that was clicked
- add a test for player gathering the targeted tile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68881259dabc832b8be0edf596d8777c