### PR TITLE
Fix path selection and spawn tile for resource gathering

### DIFF
--- a/game/main.js
+++ b/game/main.js
@@ -20,6 +20,11 @@ function createGame() {
   const saved = JSON.parse(localStorage.getItem('pazneriaGameState')) || {};
   let spawnX = saved.x !== undefined ? saved.x : Math.floor(mapWidth / 2);
   let spawnY = saved.y !== undefined ? saved.y : Math.floor(mapHeight / 2);
+  // Ensure the spawn tile is always empty so the player doesn't start
+  // on top of a resource node.
+  if (world.isWithinBounds(spawnX, spawnY)) {
+    world.tiles[spawnY][spawnX].type = 'empty';
+  }
   player = new Player(world, spawnX, spawnY);
 
   canvas.addEventListener('click', (event) => {

--- a/game/player_osrs.js
+++ b/game/player_osrs.js
@@ -18,6 +18,8 @@ export default class Player {
   }
 
   moveTo(tileX, tileY) {
+    const startX = this.x;
+    const startY = this.y;
     // If target is a resource, path to an adjacent walkable tile
     if (this.world.isResource(tileX, tileY)) {
       const candidates = [];
@@ -27,20 +29,30 @@ export default class Player {
           const nx = tileX + dx;
           const ny = tileY + dy;
           if (this.world.isWalkable(nx, ny)) {
-            const candidatePath = this.world.findPath(this.x, this.y, nx, ny);
-            if (candidatePath.length > 0) {
-              candidates.push({ path: candidatePath, nx, ny });
+            const candidatePath = this.world.findPath(startX, startY, nx, ny);
+            if (candidatePath) {
+              const dist = Math.hypot(startX - nx, startY - ny);
+              candidates.push({ path: candidatePath, nx, ny, dist });
             }
           }
         }
       }
       if (candidates.length > 0) {
-        candidates.sort((a, b) => a.path.length - b.path.length);
+        candidates.sort((a, b) => {
+          if (a.path.length === b.path.length) {
+            return a.dist - b.dist;
+          }
+          return a.path.length - b.path.length;
+        });
         this.path = candidates[0].path;
+        this.gatherTarget = { x: tileX, y: tileY };
+      } else if (Math.abs(tileX - startX) <= 1 && Math.abs(tileY - startY) <= 1) {
+        // Already adjacent with no movement required
+        this.path = [];
         this.gatherTarget = { x: tileX, y: tileY };
       }
     } else {
-      const path = this.world.findPath(this.x, this.y, tileX, tileY);
+      const path = this.world.findPath(startX, startY, tileX, tileY);
       this.path = path;
       this.gatherTarget = null;
     }

--- a/tests/player_osrs.test.js
+++ b/tests/player_osrs.test.js
@@ -33,3 +33,27 @@ test('player gathers only the targeted resource', () => {
   assert.equal(player.inventory.ore, 1);
   assert.ok(!player.inventory.scrap);
 });
+
+test('player chooses the closest adjacent tile to gather', () => {
+  globalThis.localStorage = {
+    getItem() { return null; },
+    setItem() {}
+  };
+  const world = new World();
+  // Clear map
+  for (let y = 0; y < world.height; y++) {
+    for (let x = 0; x < world.width; x++) {
+      world.tiles[y][x].type = 'empty';
+    }
+  }
+  // Place a resource two tiles east of the player
+  world.tiles[1][3] = { type: 'ore', respawnType: null, respawnTicksRemaining: 0 };
+
+  const player = new Player(world, 1, 1);
+
+  player.moveTo(3, 1);
+
+  // The first step in the path should be to the tile east of the start (2,1)
+  assert.equal(player.path[0].x, 2);
+  assert.equal(player.path[0].y, 1);
+});


### PR DESCRIPTION
## Summary
- ensure player spawn tile is cleared of resources
- refine `moveTo` logic so the closest adjacent tile is chosen when gathering resources
- add regression test for path selection logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68881575dd74832b94a9231b3ee459ef