### PR TITLE
Fix pathfinding performance and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repository contains the static files for the **Pazneria** website. It is a 
 
 The site hosts various small projects and experiments. Notably, under `game/` lives a canvas-based RPG written in JavaScript. You can open `game.html` to play the game directly in your browser.
 
-Older code for the Dataforge idle game has been removed. References remain in some of the page navigation, but the legacy implementation has been cleaned out of the repository.
+Previous experiments, such as the early *Dataforge* idle game, have since been removed to keep the repository focused on the current content.

--- a/game/player_osrs.js
+++ b/game/player_osrs.js
@@ -29,11 +29,11 @@ export default class Player {
           const nx = tileX + dx;
           const ny = tileY + dy;
           if (this.world.isWalkable(nx, ny)) {
-            const candidatePath = this.world.findPath(startX, startY, nx, ny);
-            if (candidatePath) {
-              const dist = Math.hypot(startX - nx, startY - ny);
-              candidates.push({ path: candidatePath, nx, ny, dist });
-            }
+          const candidatePath = this.world.findPath(startX, startY, nx, ny);
+          if (candidatePath && candidatePath.length > 0) {
+            const dist = Math.hypot(startX - nx, startY - ny);
+            candidates.push({ path: candidatePath, nx, ny, dist });
+          }
           }
         }
       }

--- a/game/world.js
+++ b/game/world.js
@@ -152,14 +152,15 @@ export default class World {
       { dx: -1, dy: -1 },
     ];
     const queue = [];
+    let front = 0;
     const visited = new Set();
     const key = (x, y) => `${x},${y}`;
     queue.push({ x: startX, y: startY });
     const cameFrom = {};
     visited.add(key(startX, startY));
     let found = false;
-    while (queue.length > 0) {
-      const current = queue.shift();
+    while (front < queue.length) {
+      const current = queue[front++];
       if (current.x === endX && current.y === endY) {
         found = true;
         break;


### PR DESCRIPTION
## Summary
- refine README wording about old Dataforge project
- fix candidate path handling in `player_osrs.js`
- use an efficient queue pointer in `world.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68886adbc3ac832b98889993ed83a6c2