### PR TITLE
Introduce chunk loading with camera

### DIFF
--- a/game/config.js
+++ b/game/config.js
@@ -1,6 +1,12 @@
 export const tileSize = 32;
+// Size of the visible viewport in tiles
 export const mapWidth = 20;
 export const mapHeight = 15;
+
+// Size of a single chunk. The initial world is composed of multiple chunks
+// stitched together.
+export const chunkWidth = 20;
+export const chunkHeight = 15;
 
 // Game time is measured exclusively in ticks. 100 ticks per minute means
 // one tick every 600ms.

--- a/game/entities/player.js
+++ b/game/entities/player.js
@@ -85,10 +85,15 @@ export default class Player {
     }
   }
 
-  draw(ctx) {
+  draw(ctx, cameraX = 0, cameraY = 0) {
     ctx.fillStyle = playerColor;
     // Draw as a rectangle with margin for separation
-    ctx.fillRect(this.x * tileSize + 3, this.y * tileSize + 3, tileSize - 6, tileSize - 6);
+    ctx.fillRect(
+      (this.x - cameraX) * tileSize + 3,
+      (this.y - cameraY) * tileSize + 3,
+      tileSize - 6,
+      tileSize - 6
+    );
   }
 
   saveState() {

--- a/game/main.js
+++ b/game/main.js
@@ -18,8 +18,8 @@ function createGame() {
 
   world = new World();
   const saved = JSON.parse(localStorage.getItem('pazneriaGameState')) || {};
-  let spawnX = saved.x !== undefined ? saved.x : Math.floor(mapWidth / 2);
-  let spawnY = saved.y !== undefined ? saved.y : Math.floor(mapHeight / 2);
+  let spawnX = saved.x !== undefined ? saved.x : Math.floor(world.width / 2);
+  let spawnY = saved.y !== undefined ? saved.y : Math.floor(world.height / 2);
   // Ensure the spawn tile is always empty so the player doesn't start
   // on top of a resource node.
   if (world.isWithinBounds(spawnX, spawnY)) {
@@ -29,14 +29,12 @@ function createGame() {
 
   canvas.addEventListener('click', (event) => {
     const rect = canvas.getBoundingClientRect();
-    // Scale the click position from the displayed size back to the
-    // canvas's internal coordinate system. Without this the player
-    // would walk to the wrong tile when the canvas is stretched by CSS.
     const scaleX = canvas.width / rect.width;
     const scaleY = canvas.height / rect.height;
     const pixelX = (event.clientX - rect.left) * scaleX;
     const pixelY = (event.clientY - rect.top) * scaleY;
-    const { x, y } = world.getTileCoordinates(pixelX, pixelY);
+    const { camX, camY } = getCamera();
+    const { x, y } = world.getTileCoordinates(pixelX, pixelY, camX, camY);
     player.moveTo(x, y);
   });
 
@@ -48,11 +46,20 @@ function createGame() {
   requestAnimationFrame(gameLoop);
 }
 
+function getCamera() {
+  const halfW = Math.floor(mapWidth / 2);
+  const halfH = Math.floor(mapHeight / 2);
+  const camX = Math.max(0, Math.min(player.x - halfW, world.width - mapWidth));
+  const camY = Math.max(0, Math.min(player.y - halfH, world.height - mapHeight));
+  return { camX, camY };
+}
+
 function gameLoop() {
   ctx.fillStyle = backgroundColor;
   ctx.fillRect(0, 0, canvas.width, canvas.height);
-  world.draw(ctx);
-  player.draw(ctx);
+  const { camX, camY } = getCamera();
+  world.draw(ctx, camX, camY);
+  player.draw(ctx, camX, camY);
   requestAnimationFrame(gameLoop);
 }
 


### PR DESCRIPTION
## Summary
- add chunk dimensions to config
- implement chunk-based world generation
- draw world and player relative to camera
- spawn in the center of the larger world
- compute camera position on click and in the game loop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888f9ee6844832b8a50796a150c567c