### PR TITLE
Fix gameplay focus

### DIFF
--- a/assets/game.css
+++ b/assets/game.css
@@ -45,3 +45,14 @@
   width: auto !important;
   height: auto !important;
 }
+
+/* When the game is focused, disable page interaction outside the game */
+body.game-focused {
+  overflow: hidden;
+  pointer-events: none;
+}
+
+body.game-focused #game-container {
+  pointer-events: auto;
+}
+

--- a/game/main.js
+++ b/game/main.js
@@ -36,6 +36,18 @@ function createGame() {
   minimap = new Minimap(world, player);
   minimap.attach(container);
 
+  canvas.addEventListener('contextmenu', (e) => e.preventDefault());
+
+  canvas.addEventListener('mousedown', () => {
+    document.body.classList.add('game-focused');
+  });
+
+  document.addEventListener('mousedown', (e) => {
+    if (!container.contains(e.target)) {
+      document.body.classList.remove('game-focused');
+    }
+  });
+
   canvas.addEventListener('click', (event) => {
     const rect = canvas.getBoundingClientRect();
     const scaleX = canvas.width / rect.width;


### PR DESCRIPTION
## Summary
- disable browser context menu on game canvas and add focus overlay logic
- prevent page interactions while the game window is focused

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68890951b848832bbf5e812216d800d4