### PR TITLE
Fix game window positioning

### DIFF
--- a/game/main.js
+++ b/game/main.js
@@ -14,6 +14,11 @@ let lastFrameTime = 0;
 
 function createGame() {
   const container = document.getElementById('game-container');
+  // Shift the entire game container down by two tiles so the
+  // canvas isn't flush against the header. The tileSize constant
+  // is defined in config.js, so this offset will automatically
+  // adjust if the tile dimensions change.
+  container.style.marginTop = `${tileSize * 2}px`;
   container.innerHTML = '';
   canvas = document.createElement('canvas');
   canvas.id = 'game-canvas';


### PR DESCRIPTION
## Summary
- offset the game container by two tiles to lower its vertical position

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688915767780832bbce682b09b7113c4