### PR TITLE
Add sprite sheet support for game

### DIFF
--- a/game/entities/player.js
+++ b/game/entities/player.js
@@ -19,6 +19,11 @@ export default class Player {
     // Pathfinding and gathering state
     this.path = [];
     this.gatherTarget = null;
+
+    // Sprite information; can be set externally
+    this.spriteSheet = null;
+    this.spriteOffsetX = 0;
+    this.spriteOffsetY = 0;
   }
 
   moveTo(tileX, tileY) {
@@ -86,14 +91,24 @@ export default class Player {
   }
 
   draw(ctx, cameraX = 0, cameraY = 0) {
-    ctx.fillStyle = playerColor;
-    // Draw as a rectangle with margin for separation
-    ctx.fillRect(
-      (this.x - cameraX) * tileSize + 3,
-      (this.y - cameraY) * tileSize + 3,
-      tileSize - 6,
-      tileSize - 6
-    );
+    const drawX = (this.x - cameraX) * tileSize;
+    const drawY = (this.y - cameraY) * tileSize;
+    if (this.spriteSheet && this.spriteSheet.complete) {
+      ctx.drawImage(
+        this.spriteSheet,
+        this.spriteOffsetX,
+        this.spriteOffsetY,
+        tileSize,
+        tileSize,
+        drawX,
+        drawY,
+        tileSize,
+        tileSize
+      );
+    } else {
+      ctx.fillStyle = playerColor;
+      ctx.fillRect(drawX + 3, drawY + 3, tileSize - 6, tileSize - 6);
+    }
   }
 
   saveState() {

--- a/game/main.js
+++ b/game/main.js
@@ -4,6 +4,19 @@ import Player from './entities/player.js';
 import Camera from './camera.js';
 import Minimap from './minimap.js';
 
+// Load character sprite sheet and resource icons
+const characterSprite = new Image();
+characterSprite.src = './RPGCharacterSprites32x32.png';
+
+const oreImage = new Image();
+oreImage.src = './ore.png';
+
+const logImage = new Image();
+logImage.src = './log.png';
+
+const tileImage = new Image();
+tileImage.src = './Futuristic Industrial Tileset.png';
+
 let world;
 let player;
 let camera;
@@ -25,6 +38,8 @@ function createGame() {
   ctx = canvas.getContext('2d');
 
   world = new World();
+  // Provide resource and tile images to the world
+  world.images = { ore: oreImage, logs: logImage, tile: tileImage };
   const saved = JSON.parse(localStorage.getItem('pazneriaGameState')) || {};
   let spawnX = saved.x !== undefined ? saved.x : Math.floor(world.width / 2);
   let spawnY = saved.y !== undefined ? saved.y : Math.floor(world.height / 2);
@@ -34,6 +49,10 @@ function createGame() {
     world.tiles[spawnY][spawnX].type = 'empty';
   }
   player = new Player(world, spawnX, spawnY);
+  // Assign sprite sheet to the player
+  player.spriteSheet = characterSprite;
+  player.spriteOffsetX = 0;
+  player.spriteOffsetY = 0;
   camera = new Camera(world, player);
   minimap = new Minimap(world, player);
   minimap.attach(container);

--- a/game/world/world.js
+++ b/game/world/world.js
@@ -18,6 +18,8 @@ export default class World {
     this.width = 0;
     this.height = 0;
     this.chunks = new Set();
+    // Holds images for resources and tiles
+    this.images = {};
 
     for (let cy = 0; cy <= chunkRadius * 2; cy++) {
       for (let cx = 0; cx <= chunkRadius * 2; cx++) {
@@ -52,9 +54,27 @@ export default class World {
   }
 
   draw(ctx, cameraX = 0, cameraY = 0) {
-    // Fill background for the visible area
-    ctx.fillStyle = defaultTileColor;
-    ctx.fillRect(0, 0, mapWidth * tileSize, mapHeight * tileSize);
+    // Fill background with tile image or fallback color
+    if (this.images.tile && this.images.tile.complete) {
+      for (let y = 0; y < mapHeight; y++) {
+        for (let x = 0; x < mapWidth; x++) {
+          ctx.drawImage(
+            this.images.tile,
+            0,
+            0,
+            16,
+            16,
+            x * tileSize,
+            y * tileSize,
+            tileSize,
+            tileSize
+          );
+        }
+      }
+    } else {
+      ctx.fillStyle = defaultTileColor;
+      ctx.fillRect(0, 0, mapWidth * tileSize, mapHeight * tileSize);
+    }
 
     const baseX = Math.floor(cameraX);
     const baseY = Math.floor(cameraY);
@@ -73,8 +93,23 @@ export default class World {
         const tile = this.tiles[wy][wx];
         if (!tile) continue;
         if (tile.type !== 'empty') {
-          ctx.fillStyle = resourceColors[tile.type];
-          ctx.fillRect(vx * tileSize, vy * tileSize, tileSize, tileSize);
+          const img = this.images[tile.type];
+          if (img && img.complete) {
+            ctx.drawImage(
+              img,
+              0,
+              0,
+              img.width,
+              img.height,
+              vx * tileSize,
+              vy * tileSize,
+              tileSize,
+              tileSize
+            );
+          } else {
+            ctx.fillStyle = resourceColors[tile.type];
+            ctx.fillRect(vx * tileSize, vy * tileSize, tileSize, tileSize);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- load sprite sheet and resource images in `main.js`
- allow `Player` sprite sheet rendering
- render world background and resources using images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889561de80c832b8618ff5c88cc34f7