### PR TITLE
Improve player sprite direction and transparency

### DIFF
--- a/assets/game.css
+++ b/assets/game.css
@@ -5,7 +5,8 @@
   /* Height of the footer used in layout calculations */
   --footer-height: 50px;
   /* Additional top spacing for the game container */
-  --game-offset: 20px;
+  /* Shift the entire game window further down */
+  --game-offset: 40px;
 }
 
 main {

--- a/game/entities/player.js
+++ b/game/entities/player.js
@@ -24,6 +24,7 @@ export default class Player {
     this.spriteSheet = null;
     this.spriteOffsetX = 0;
     this.spriteOffsetY = 0;
+    this.direction = 'south';
   }
 
   moveTo(tileX, tileY) {
@@ -71,6 +72,13 @@ export default class Player {
     // Execute one step along path each tick
     if (this.path && this.path.length > 0) {
       const nextTile = this.path.shift();
+      const dx = nextTile.x - this.x;
+      const dy = nextTile.y - this.y;
+      if (Math.abs(dx) > Math.abs(dy)) {
+        this.direction = dx > 0 ? 'east' : 'west';
+      } else if (dy !== 0) {
+        this.direction = dy > 0 ? 'south' : 'north';
+      }
       this.x = nextTile.x;
       this.y = nextTile.y;
       // Update pixel coordinates for drawing
@@ -94,9 +102,15 @@ export default class Player {
     const drawX = (this.x - cameraX) * tileSize;
     const drawY = (this.y - cameraY) * tileSize;
     if (this.spriteSheet && this.spriteSheet.complete) {
+      const dirOffset = {
+        south: 0,
+        west: 3,
+        east: 6,
+        north: 9,
+      }[this.direction] * tileSize + this.spriteOffsetX;
       ctx.drawImage(
         this.spriteSheet,
-        this.spriteOffsetX,
+        dirOffset,
         this.spriteOffsetY,
         tileSize,
         tileSize,

--- a/game/main.js
+++ b/game/main.js
@@ -7,6 +7,22 @@ import Minimap from './minimap.js';
 // Load character sprite sheet and resource icons
 const characterSprite = new Image();
 characterSprite.src = new URL('./RPGCharacterSprites32x32.png', import.meta.url).href;
+characterSprite.onload = () => {
+  const off = document.createElement('canvas');
+  off.width = characterSprite.width;
+  off.height = characterSprite.height;
+  const octx = off.getContext('2d');
+  octx.drawImage(characterSprite, 0, 0);
+  const imgData = octx.getImageData(0, 0, off.width, off.height);
+  const data = imgData.data;
+  for (let i = 0; i < data.length; i += 4) {
+    if (data[i] === 255 && data[i + 1] === 0 && data[i + 2] === 255) {
+      data[i + 3] = 0;
+    }
+  }
+  octx.putImageData(imgData, 0, 0);
+  characterSprite.src = off.toDataURL();
+};
 
 const oreImage = new Image();
 oreImage.src = new URL('./ore.png', import.meta.url).href;


### PR DESCRIPTION
## Summary
- move the game window a little further down so it's not flush with the nav
- make player face the direction they're travelling
- clean up the sprite sheet's magenta background before use

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68896979e6ec832b8bebc9a01ccbbb22