### PR TITLE
Add tree outline rendering

### DIFF
--- a/game/renderUtils.js
+++ b/game/renderUtils.js
@@ -1,0 +1,26 @@
+export function drawOutlinedImage(
+  ctx,
+  img,
+  sx,
+  sy,
+  sw,
+  sh,
+  dx,
+  dy,
+  dw,
+  dh,
+  color = '#000'
+) {
+  ctx.save();
+  for (let offY = -1; offY <= 1; offY++) {
+    for (let offX = -1; offX <= 1; offX++) {
+      if (offX === 0 && offY === 0) continue;
+      ctx.drawImage(img, sx, sy, sw, sh, dx + offX, dy + offY, dw, dh);
+    }
+  }
+  ctx.globalCompositeOperation = 'source-in';
+  ctx.fillStyle = color;
+  ctx.fillRect(dx - 1, dy - 1, dw + 2, dh + 2);
+  ctx.restore();
+  ctx.drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh);
+}

--- a/game/world/world.js
+++ b/game/world/world.js
@@ -9,6 +9,9 @@ import {
   resourceDefinitions,
 } from '../config.js';
 import { worldMap } from './chunks/index.js';
+import { drawOutlinedImage } from '../renderUtils.js';
+
+const outlinedTypes = new Set(['oakTree']);
 
 export default class World {
   constructor() {
@@ -125,17 +128,35 @@ export default class World {
         if (tile.type !== 'empty') {
           const img = this.images[tile.type];
           if (img && img.complete) {
-            ctx.drawImage(
-              img,
-              0,
-              0,
-              img.width,
-              img.height,
-              wx * tileSize,
-              wy * tileSize,
-              tileSize,
-              tileSize
-            );
+            const dx = wx * tileSize;
+            const dy = wy * tileSize;
+            if (outlinedTypes.has(tile.type)) {
+              drawOutlinedImage(
+                ctx,
+                img,
+                0,
+                0,
+                img.width,
+                img.height,
+                dx,
+                dy,
+                tileSize,
+                tileSize,
+                '#003300'
+              );
+            } else {
+              ctx.drawImage(
+                img,
+                0,
+                0,
+                img.width,
+                img.height,
+                dx,
+                dy,
+                tileSize,
+                tileSize
+              );
+            }
           } else {
             ctx.fillStyle = resourceColors[tile.type];
             ctx.fillRect(wx * tileSize, wy * tileSize, tileSize, tileSize);


### PR DESCRIPTION
## Summary
- implement `drawOutlinedImage` helper
- use the helper in `World.draw` to outline tree sprites

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d59626ba0832b84a1b1e823efdf6c