### PR TITLE
Use tree sprite sheet for resources

### DIFF
--- a/game/config.js
+++ b/game/config.js
@@ -23,10 +23,22 @@ export const resourceColors = {
   oakTree: '#aa8844',
 };
 
-export const resourceImagePaths = {
-  copperOre: '../game_assets/assets/ores/copper/copper.png',
-  tinOre: '../game_assets/assets/ores/tin/tin.png',
-  oakTree: '../game_assets/assets/trees/oak/oak.png',
+export const resourceSprites = {
+  copperOre: {
+    src: '../game_assets/assets/ores/copper/copper.png',
+    sx: 0,
+    sy: 0,
+  },
+  tinOre: {
+    src: '../game_assets/assets/ores/tin/tin.png',
+    sx: 0,
+    sy: 0,
+  },
+  oakTree: {
+    src: '../game_assets/assets/trees/Trees.png',
+    sx: 0,
+    sy: 0,
+  },
 };
 
 export const resourceDefinitions = {

--- a/game/main.js
+++ b/game/main.js
@@ -4,14 +4,14 @@ import {
   mapHeight,
   backgroundColor,
   tickDuration,
-  resourceImagePaths,
+  resourceSprites,
 } from './config.js';
 import World from './world/world.js';
 import Player from './entities/player.js';
 import Camera from './camera.js';
 import Minimap from './minimap.js';
 
-// Load character sprite sheet and resource icons
+// Load character sprite sheet and resource sprites
 const characterSprite = new Image();
 characterSprite.addEventListener(
   'load',
@@ -35,14 +35,12 @@ characterSprite.addEventListener(
 );
 characterSprite.src = new URL('./RPGCharacterSprites32x32.png', import.meta.url).href;
 
-const copperOreImage = new Image();
-copperOreImage.src = new URL(resourceImagePaths.copperOre, import.meta.url).href;
-
-const tinOreImage = new Image();
-tinOreImage.src = new URL(resourceImagePaths.tinOre, import.meta.url).href;
-
-const oakTreeImage = new Image();
-oakTreeImage.src = new URL(resourceImagePaths.oakTree, import.meta.url).href;
+const resourceSpriteImages = {};
+for (const [key, def] of Object.entries(resourceSprites)) {
+  const img = new Image();
+  img.src = new URL(def.src, import.meta.url).href;
+  resourceSpriteImages[key] = { image: img, sx: def.sx, sy: def.sy };
+}
 
 const tileImage = new Image();
 tileImage.src = new URL('./grass_tile.png', import.meta.url).href;
@@ -69,12 +67,8 @@ function createGame() {
 
   world = new World();
   // Provide resource and tile images to the world
-  world.images = {
-    copperOre: copperOreImage,
-    tinOre: tinOreImage,
-    oakTree: oakTreeImage,
-    tile: tileImage,
-  };
+  world.images = { tile: tileImage };
+  world.resourceSprites = resourceSpriteImages;
   const saved = JSON.parse(localStorage.getItem('pazneriaGameState')) || {};
   let spawnX = saved.x !== undefined ? saved.x : Math.floor(world.width / 2);
   let spawnY = saved.y !== undefined ? saved.y : Math.floor(world.height / 2);

--- a/game/world/world.js
+++ b/game/world/world.js
@@ -18,6 +18,7 @@ export default class World {
     this.chunkWidth = chunkWidth;
     this.chunkHeight = chunkHeight;
     this.images = {};
+    this.resourceSprites = {};
     this.loadedChunks = new Map(); // key -> tile data
     this.worldMap = worldMap;
 
@@ -126,18 +127,18 @@ export default class World {
         const tile = this.getTile(wx, wy);
         if (!tile) continue;
         if (tile.type !== 'empty') {
-          const img = this.images[tile.type];
-          if (img && img.complete) {
+          const sprite = this.resourceSprites[tile.type];
+          if (sprite && sprite.image.complete) {
             const dx = wx * tileSize;
             const dy = wy * tileSize;
             if (outlinedTypes.has(tile.type)) {
               drawOutlinedImage(
                 ctx,
-                img,
-                0,
-                0,
-                img.width,
-                img.height,
+                sprite.image,
+                sprite.sx,
+                sprite.sy,
+                tileSize,
+                tileSize,
                 dx,
                 dy,
                 tileSize,
@@ -146,11 +147,11 @@ export default class World {
               );
             } else {
               ctx.drawImage(
-                img,
-                0,
-                0,
-                img.width,
-                img.height,
+                sprite.image,
+                sprite.sx,
+                sprite.sy,
+                tileSize,
+                tileSize,
                 dx,
                 dy,
                 tileSize,


### PR DESCRIPTION
## Summary
- load tree sprites from `Trees.png` sheet using sprite offsets
- reference resource sprite definitions in config and world rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d5d8cbfac832bb85b4a06e7bc9172