### PR TITLE
Revert tree sprite to stable log asset

### DIFF
--- a/game/config.js
+++ b/game/config.js
@@ -35,7 +35,7 @@ export const resourceSprites = {
     sy: 0,
   },
   oakTree: {
-    src: '../game_assets/assets/trees/Trees.png',
+    src: './log.png',
     sx: 0,
     sy: 0,
   },


### PR DESCRIPTION
## Summary
- Restore oak tree to previous log-based sprite to avoid disappearing objects after refresh

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d6b673400832ba86f4d317274c359