### PR TITLE
fix: draw grass tiles and preload chunks

### DIFF
--- a/game/entities/player.js
+++ b/game/entities/player.js
@@ -71,8 +71,6 @@ export default class Player {
   }
 
   update() {
-    // Ensure nearby chunks are loaded before movement
-    this.world.ensureChunksAround(this.x, this.y);
     // Execute one step along path each tick
     if (this.path && this.path.length > 0) {
       const nextTile = this.path.shift();
@@ -104,6 +102,9 @@ export default class Player {
       }
       this.isMoving = false;
     }
+
+    // Ensure nearby chunks are loaded after any movement
+    this.world.ensureChunksAround(this.x, this.y);
   }
 
   draw(ctx, cameraX = 0, cameraY = 0) {

--- a/game/world/world.js
+++ b/game/world/world.js
@@ -94,15 +94,27 @@ export default class World {
     ctx.save();
     ctx.translate(-cameraX * tileSize, -cameraY * tileSize);
 
-    if (this.images.tile && this.images.tile.complete) {
+    // Always paint a base color so missing tiles don't show the canvas background
+    ctx.fillStyle = defaultTileColor;
+    ctx.fillRect(
+      baseX * tileSize,
+      baseY * tileSize,
+      (mapWidth + 1) * tileSize,
+      (mapHeight + 1) * tileSize
+    );
+
+    const tile = this.images.tile;
+    if (tile && tile.complete && tile.naturalWidth > 0 && tile.naturalHeight > 0) {
+      const srcW = tile.naturalWidth;
+      const srcH = tile.naturalHeight;
       for (let y = baseY; y <= baseY + mapHeight; y++) {
         for (let x = baseX; x <= baseX + mapWidth; x++) {
           ctx.drawImage(
-            this.images.tile,
+            tile,
             0,
             0,
-            16,
-            16,
+            srcW,
+            srcH,
             x * tileSize,
             y * tileSize,
             tileSize,
@@ -110,14 +122,6 @@ export default class World {
           );
         }
       }
-    } else {
-      ctx.fillStyle = defaultTileColor;
-      ctx.fillRect(
-        baseX * tileSize,
-        baseY * tileSize,
-        (mapWidth + 1) * tileSize,
-        (mapHeight + 1) * tileSize
-      );
     }
 
     for (let vy = 0; vy <= mapHeight; vy++) {


### PR DESCRIPTION
## Summary
- Ensure background tiles render by drawing the full grass texture and always painting a base color
- Load neighbouring chunks after the player moves to avoid pop-in rendering gaps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d8198d24c832b8369f576555ef69d