### PR TITLE
Point navigation Game tab to the prototype directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This repository contains the static files for the **Pazneria** website. It is a simple static site composed of HTML, CSS and JavaScript.
 
-The site hosts various small projects and experiments. Notably, under `game/` lives a canvas-based RPG written in JavaScript. You can open `game.html` to play the game directly in your browser.
+The site hosts various small projects and experiments. Notably, under `game/` lives a canvas-based RPG written in JavaScript. Open the `game/` directory (e.g. visit `/game/` in the browser) to launch the prototype.
 
 Previous experiments, such as the early *Dataforge* idle game, have since been removed to keep the repository focused on the current content.

--- a/about.html
+++ b/about.html
@@ -22,7 +22,7 @@
       <ul class="nav-list">
         <li><a href="index.html" class="nav-link">Home</a></li>
         <li><a href="agi.html" class="nav-link">AGI Forecasting</a></li>
-        <li><a href="game.html" class="nav-link">Game</a></li>
+        <li><a href="game/" class="nav-link">Game</a></li>
         <li><a href="about.html" class="nav-link">About</a></li>
         <li><a href="contact.html" class="nav-link">Contact</a></li>
       </ul>

--- a/contact.html
+++ b/contact.html
@@ -21,7 +21,7 @@
       <ul class="nav-list">
         <li><a href="index.html" class="nav-link">Home</a></li>
         <li><a href="agi.html" class="nav-link">AGI Forecasting</a></li>
-        <li><a href="game.html" class="nav-link">Game</a></li>
+        <li><a href="game/" class="nav-link">Game</a></li>
         <li><a href="about.html" class="nav-link">About</a></li>
         <li><a href="contact.html" class="nav-link">Contact</a></li>
       </ul>

--- a/game/README.md
+++ b/game/README.md
@@ -1,0 +1,20 @@
+# Pazneria Prototype Game
+
+This directory contains the front-end only prototype for the Pazneria game. It mirrors the eventual project layout so you can plug in richer systems later without restructuring the site.
+
+## Structure
+
+```
+src/          Core game modules (world, player, skills)
+assets/       Placeholder for sprites, audio, fonts
+data/         JSON definitions for items, objects, maps and NPCs
+```
+
+The prototype runs entirely in the browser. No build step or bundler is required; everything is native ES modules.
+
+## Extending
+
+* Flesh out `data/` to add more items, objects and map regions.
+* Swap the drawing logic in `world.js` for sprite rendering once assets land in `assets/`.
+* Replace the interval-based main loop with `requestAnimationFrame` when you need smoother movement.
+* Expand `skills/` with additional skill handlers following the woodcutting example.

--- a/game/assets/README.md
+++ b/game/assets/README.md
@@ -1,0 +1,3 @@
+# Assets Placeholder
+
+Drop sprite sheets, UI icons and audio files here. The current prototype renders primitive shapes, but the directory exists so you can begin sketching art pipelines without altering imports.

--- a/game/data/items.json
+++ b/game/data/items.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "logs",
+    "name": "Logs",
+    "description": "A bundle of freshly cut logs. Useful for fletching or firemaking later.",
+    "value": 2
+  },
+  {
+    "id": "bronze_axe",
+    "name": "Bronze Axe",
+    "description": "A trusty beginner's axe."
+  }
+]

--- a/game/data/maps/region_0_0.json
+++ b/game/data/maps/region_0_0.json
@@ -1,0 +1,30 @@
+{
+  "name": "Starter Clearing",
+  "width": 16,
+  "height": 16,
+  "spawn": { "x": 8, "y": 8 },
+  "tiles": [
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"],
+    ["grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass","grass"]
+  ],
+  "objects": [
+    { "id": "tree_oak", "x": 5, "y": 6 },
+    { "id": "tree_oak", "x": 10, "y": 7 },
+    { "id": "tree_oak", "x": 7, "y": 10 },
+    { "id": "campfire", "x": 8, "y": 9 }
+  ]
+}

--- a/game/data/npcs.json
+++ b/game/data/npcs.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "guide",
+    "name": "Settler Guide",
+    "position": { "x": 6, "y": 9 },
+    "dialogue": [
+      "Welcome to the clearing!",
+      "These woods are ripe for experimentation.",
+      "Everything you see runs entirely in the browser."
+    ]
+  }
+]

--- a/game/data/objects.json
+++ b/game/data/objects.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "tree_oak",
+    "name": "Oak Tree",
+    "skill": "woodcutting",
+    "solid": true,
+    "color": "#2f8f2f",
+    "skillData": {
+      "level": 1,
+      "successRate": 80,
+      "yield": "logs",
+      "respawnTicks": 6,
+      "replacement": "stump_oak"
+    }
+  },
+  {
+    "id": "stump_oak",
+    "name": "Oak Stump",
+    "solid": false,
+    "color": "#6b4b2c",
+    "states": {
+      "stump": {
+        "color": "#6b4b2c"
+      }
+    },
+    "skillData": {
+      "respawnTicks": 6,
+      "replacement": "tree_oak"
+    }
+  },
+  {
+    "id": "campfire",
+    "name": "Campfire",
+    "solid": false,
+    "color": "#ffb347"
+  }
+]

--- a/game/docs/roadmap.md
+++ b/game/docs/roadmap.md
@@ -1,0 +1,16 @@
+# Prototype Roadmap
+
+## Short Term
+- Improve collision so world objects can occupy multiple tiles.
+- Implement sprite rendering and load placeholder assets.
+- Add mining as a second gathering skill.
+
+## Medium Term
+- Replace the fixed tick with a proper game loop and delta timing.
+- Create a dialogue system for NPC interactions.
+- Persist player save data in localStorage during development.
+
+## Long Term
+- Author more map regions and connect them via region streaming.
+- Prototype a quest scripting format under `data/quests/`.
+- Explore syncing lightweight state to a backend service once needed.

--- a/game/index.html
+++ b/game/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pazneria - Prototype Game</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <header class="game-header">
+    <h1>Pazneria Prototype</h1>
+    <p class="tagline">An experimental, single-player OSRS-inspired sandbox.</p>
+  </header>
+  <main class="game-layout">
+    <section class="gameplay">
+      <canvas id="game-canvas" width="512" height="512" aria-label="Game world"></canvas>
+      <div class="hint">Use the arrow keys to move and space to interact.</div>
+    </section>
+    <aside class="game-ui" aria-live="polite">
+      <section class="panel">
+        <h2>Inventory</h2>
+        <ul id="inventory" class="inventory"></ul>
+      </section>
+      <section class="panel">
+        <h2>Activity Log</h2>
+        <ul id="log" class="log"></ul>
+      </section>
+    </aside>
+  </main>
+  <footer class="game-footer">
+    <p>This is an early prototype. Systems, assets and data files are intentionally lightweight.</p>
+  </footer>
+  <script type="module" src="./src/game.js"></script>
+</body>
+</html>

--- a/game/src/entity.js
+++ b/game/src/entity.js
@@ -1,0 +1,20 @@
+export class Entity {
+  constructor({ x = 0, y = 0 } = {}) {
+    this.x = x;
+    this.y = y;
+  }
+
+  move(dx, dy) {
+    this.x += dx;
+    this.y += dy;
+  }
+
+  setPosition(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  get position() {
+    return { x: this.x, y: this.y };
+  }
+}

--- a/game/src/game.js
+++ b/game/src/game.js
@@ -1,0 +1,120 @@
+import { World, TILE_SIZE } from './world.js';
+import { Player } from './player.js';
+import { UI } from './ui.js';
+import { loadData } from './utils.js';
+import { registerWoodcutting } from './skills/woodcutting.js';
+
+const TICK_MS = 600;
+
+const inputState = {
+  up: false,
+  down: false,
+  left: false,
+  right: false,
+  action: false
+};
+
+document.addEventListener('keydown', (event) => {
+  if (event.repeat) return;
+  switch (event.key) {
+    case 'ArrowUp':
+    case 'w':
+      inputState.up = true;
+      break;
+    case 'ArrowDown':
+    case 's':
+      inputState.down = true;
+      break;
+    case 'ArrowLeft':
+    case 'a':
+      inputState.left = true;
+      break;
+    case 'ArrowRight':
+    case 'd':
+      inputState.right = true;
+      break;
+    case ' ':
+    case 'Enter':
+      inputState.action = true;
+      break;
+    default:
+      break;
+  }
+});
+
+document.addEventListener('keyup', (event) => {
+  switch (event.key) {
+    case 'ArrowUp':
+    case 'w':
+      inputState.up = false;
+      break;
+    case 'ArrowDown':
+    case 's':
+      inputState.down = false;
+      break;
+    case 'ArrowLeft':
+    case 'a':
+      inputState.left = false;
+      break;
+    case 'ArrowRight':
+    case 'd':
+      inputState.right = false;
+      break;
+    case ' ':
+    case 'Enter':
+      inputState.action = false;
+      break;
+    default:
+      break;
+  }
+});
+
+async function init() {
+  const canvas = document.getElementById('game-canvas');
+  const inventoryEl = document.getElementById('inventory');
+  const logEl = document.getElementById('log');
+
+  if (!canvas || !inventoryEl || !logEl) {
+    console.error('Game root elements missing');
+    return;
+  }
+
+  const ctx = canvas.getContext('2d');
+  const data = await loadData();
+
+  const world = new World(data.region, data.objects);
+  const player = new Player(world, data.items);
+  const ui = new UI({ inventoryEl, logEl, items: data.items });
+
+  const woodcutting = registerWoodcutting({ player, world, ui, items: data.items });
+
+  const tick = () => {
+    const performedAction = player.update(inputState);
+    if (performedAction) {
+      const target = world.objectAt(player.x, player.y) ?? world.objectAt(player.x, player.y - 1);
+      if (target && target.skill === 'woodcutting') {
+        woodcutting(target);
+      } else if (target) {
+        ui.log(`You inspect the ${target.definition.name}.`);
+      } else {
+        ui.log('There is nothing interesting here.');
+      }
+      inputState.action = false;
+    }
+
+    world.draw(ctx);
+    drawPlayer(ctx, player);
+    ui.renderInventory(player.inventory);
+  };
+
+  tick();
+  setInterval(tick, TICK_MS);
+  ui.log('Welcome to the starter clearing. Try chopping a tree.');
+}
+
+function drawPlayer(ctx, player) {
+  ctx.fillStyle = '#f5f7fa';
+  ctx.fillRect(player.x * TILE_SIZE + 8, player.y * TILE_SIZE + 8, TILE_SIZE - 16, TILE_SIZE - 16);
+}
+
+init();

--- a/game/src/objects.js
+++ b/game/src/objects.js
@@ -1,0 +1,35 @@
+export class WorldObject {
+  constructor(id, definition, { x, y }) {
+    this.id = id;
+    this.definition = definition;
+    this.x = x;
+    this.y = y;
+    this.state = 'default';
+  }
+
+  get isSolid() {
+    return this.definition.solid ?? true;
+  }
+
+  get skill() {
+    return this.definition.skill;
+  }
+
+  resetAfter(ms, callback) {
+    setTimeout(() => {
+      this.state = 'default';
+      if (callback) callback(this);
+    }, ms);
+  }
+}
+
+export function instantiateObjects(objectPlacements, definitions) {
+  const map = new Map(definitions.map((def) => [def.id, def]));
+  return objectPlacements
+    .map((placement) => {
+      const definition = map.get(placement.id);
+      if (!definition) return null;
+      return new WorldObject(placement.id, definition, placement);
+    })
+    .filter(Boolean);
+}

--- a/game/src/player.js
+++ b/game/src/player.js
@@ -1,0 +1,61 @@
+import { Entity } from './entity.js';
+import { clamp } from './utils.js';
+
+const DIRECTIONS = {
+  up: { dx: 0, dy: -1 },
+  down: { dx: 0, dy: 1 },
+  left: { dx: -1, dy: 0 },
+  right: { dx: 1, dy: 0 }
+};
+
+export class Player extends Entity {
+  constructor(world, items) {
+    super({ x: world.spawn.x, y: world.spawn.y });
+    this.world = world;
+    this.items = items;
+    this.inventory = [];
+    this.actionCooldown = 0;
+    this.maxInventory = 28;
+  }
+
+  update(input) {
+    if (this.actionCooldown > 0) {
+      this.actionCooldown -= 1;
+    }
+
+    const direction = this.resolveDirection(input);
+    if (direction) {
+      this.tryMove(direction.dx, direction.dy);
+    }
+
+    return input.action && this.actionCooldown === 0;
+  }
+
+  resolveDirection(input) {
+    if (input.up) return DIRECTIONS.up;
+    if (input.down) return DIRECTIONS.down;
+    if (input.left) return DIRECTIONS.left;
+    if (input.right) return DIRECTIONS.right;
+    return null;
+  }
+
+  tryMove(dx, dy) {
+    const targetX = clamp(this.x + dx, 0, this.world.width - 1);
+    const targetY = clamp(this.y + dy, 0, this.world.height - 1);
+    if (this.world.isBlocked(targetX, targetY)) return false;
+    this.move(targetX - this.x, targetY - this.y);
+    return true;
+  }
+
+  addItem(itemId) {
+    if (this.inventory.length >= this.maxInventory) {
+      return false;
+    }
+    this.inventory.push(itemId);
+    return true;
+  }
+
+  setCooldown(ticks) {
+    this.actionCooldown = ticks;
+  }
+}

--- a/game/src/skills/woodcutting.js
+++ b/game/src/skills/woodcutting.js
@@ -1,0 +1,44 @@
+import { roll } from '../utils.js';
+
+export function registerWoodcutting({ player, world, ui, items }) {
+  const logs = items.find((item) => item.id === 'logs');
+  const message = (text) => ui.log(`[Woodcutting] ${text}`);
+
+  return function attemptWoodcut(target) {
+    if (!target || target.skill !== 'woodcutting') {
+      message('There is nothing to chop.');
+      return false;
+    }
+
+    const { level = 1, successRate = 75, respawnTicks = 6, yield: yieldId = 'logs', replacement } =
+      target.definition.skillData ?? {};
+
+    if (player.inventory.length >= player.maxInventory) {
+      message('Your inventory is too full.');
+      return false;
+    }
+
+    if (player.setCooldown) {
+      player.setCooldown(respawnTicks);
+    }
+
+    if (roll(successRate)) {
+      player.addItem(yieldId);
+      const item = items.find((i) => i.id === yieldId) ?? logs;
+      message(`You receive ${item?.name ?? yieldId}.`);
+      target.state = 'stump';
+      if (replacement) {
+        world.replaceObject(target, replacement);
+      } else {
+        world.removeObject(target);
+        target.resetAfter(respawnTicks * 600, (obj) => {
+          world.objects.push(obj);
+        });
+      }
+      return true;
+    }
+
+    message('You swing your axe, but fail to get any logs.');
+    return false;
+  };
+}

--- a/game/src/ui.js
+++ b/game/src/ui.js
@@ -1,0 +1,36 @@
+const LOG_LIMIT = 8;
+
+export class UI {
+  constructor({ inventoryEl, logEl, items }) {
+    this.inventoryEl = inventoryEl;
+    this.logEl = logEl;
+    this.items = new Map(items.map((item) => [item.id, item]));
+  }
+
+  renderInventory(ids) {
+    this.inventoryEl.innerHTML = '';
+    if (!ids.length) {
+      const li = document.createElement('li');
+      li.textContent = 'Empty';
+      li.classList.add('empty');
+      this.inventoryEl.append(li);
+      return;
+    }
+
+    ids.forEach((id) => {
+      const li = document.createElement('li');
+      const item = this.items.get(id);
+      li.textContent = item ? item.name : id;
+      this.inventoryEl.append(li);
+    });
+  }
+
+  log(message) {
+    const entry = document.createElement('li');
+    entry.textContent = message;
+    this.logEl.prepend(entry);
+    while (this.logEl.children.length > LOG_LIMIT) {
+      this.logEl.lastChild.remove();
+    }
+  }
+}

--- a/game/src/utils.js
+++ b/game/src/utils.js
@@ -1,0 +1,29 @@
+const DATA_PATHS = {
+  items: './data/items.json',
+  objects: './data/objects.json',
+  npcs: './data/npcs.json',
+  region: './data/maps/region_0_0.json'
+};
+
+export async function loadData() {
+  const [items, objects, npcs, region] = await Promise.all([
+    fetch(DATA_PATHS.items).then((r) => r.json()),
+    fetch(DATA_PATHS.objects).then((r) => r.json()),
+    fetch(DATA_PATHS.npcs).then((r) => r.json()),
+    fetch(DATA_PATHS.region).then((r) => r.json())
+  ]);
+
+  return { items, objects, npcs, region };
+}
+
+export function roll(percent) {
+  return Math.random() * 100 < percent;
+}
+
+export function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function manhattanDistance(a, b) {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}

--- a/game/src/world.js
+++ b/game/src/world.js
@@ -1,0 +1,73 @@
+import { instantiateObjects } from './objects.js';
+
+const TILE_SIZE = 32;
+const TILE_COLORS = {
+  grass: '#1f6f2f',
+  water: '#1c4b82',
+  sand: '#ba9b65',
+  stone: '#686868'
+};
+
+export class World {
+  constructor(regionData, objectDefinitions) {
+    this.name = regionData.name;
+    this.width = regionData.width;
+    this.height = regionData.height;
+    this.tiles = regionData.tiles;
+    this.spawn = regionData.spawn ?? { x: Math.floor(this.width / 2), y: Math.floor(this.height / 2) };
+    this.objects = instantiateObjects(regionData.objects ?? [], objectDefinitions);
+    this.objectDefinitions = objectDefinitions;
+  }
+
+  tileAt(x, y) {
+    if (!this.inBounds(x, y)) return 'void';
+    return this.tiles[y][x];
+  }
+
+  inBounds(x, y) {
+    return x >= 0 && y >= 0 && x < this.width && y < this.height;
+  }
+
+  isBlocked(x, y) {
+    if (!this.inBounds(x, y)) return true;
+    const tile = this.tileAt(x, y);
+    if (tile === 'water') return true;
+    return this.objects.some((obj) => obj.x === x && obj.y === y && obj.isSolid && obj.state === 'default');
+  }
+
+  objectAt(x, y) {
+    return this.objects.find((obj) => obj.x === x && obj.y === y);
+  }
+
+  replaceObject(target, replacementId) {
+    const index = this.objects.indexOf(target);
+    const definition = this.objectDefinitions.find((obj) => obj.id === replacementId);
+    if (index === -1 || !definition) return;
+    this.objects[index] = instantiateObjects([{ id: replacementId, x: target.x, y: target.y }], this.objectDefinitions)[0];
+  }
+
+  removeObject(target) {
+    this.objects = this.objects.filter((obj) => obj !== target);
+  }
+
+  draw(ctx) {
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    for (let y = 0; y < this.height; y += 1) {
+      for (let x = 0; x < this.width; x += 1) {
+        const tile = this.tileAt(x, y);
+        ctx.fillStyle = TILE_COLORS[tile] ?? '#101419';
+        ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+      }
+    }
+
+    this.objects.forEach((obj) => {
+      ctx.fillStyle = obj.definition.color ?? '#8ccf3f';
+      if (obj.state === 'stump' && obj.definition.states?.stump?.color) {
+        ctx.fillStyle = obj.definition.states.stump.color;
+      }
+      ctx.fillRect(obj.x * TILE_SIZE + 4, obj.y * TILE_SIZE + 4, TILE_SIZE - 8, TILE_SIZE - 8);
+    });
+  }
+}
+
+export { TILE_SIZE };

--- a/game/styles.css
+++ b/game/styles.css
@@ -1,0 +1,126 @@
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  --panel-bg: rgba(24, 28, 36, 0.85);
+  --border: rgba(255, 255, 255, 0.08);
+  --accent: #8ccf3f;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top, #1b2735, #090a0f);
+  color: #f5f7fa;
+}
+
+.game-header,
+.game-footer {
+  padding: 1.5rem;
+  text-align: center;
+  background: rgba(9, 10, 15, 0.8);
+  border-bottom: 1px solid var(--border);
+}
+
+.game-footer {
+  border-top: 1px solid var(--border);
+  border-bottom: none;
+  font-size: 0.85rem;
+  margin-top: auto;
+}
+
+.tagline {
+  margin-top: 0.5rem;
+  font-weight: 300;
+  color: rgba(245, 247, 250, 0.75);
+}
+
+.game-layout {
+  display: grid;
+  gap: 1.5rem;
+  padding: 2rem;
+  grid-template-columns: minmax(0, 1fr) 320px;
+}
+
+.gameplay {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+#game-canvas {
+  border: 4px solid rgba(255, 255, 255, 0.15);
+  background: #0f141a;
+  image-rendering: pixelated;
+}
+
+.hint {
+  font-size: 0.9rem;
+  color: rgba(245, 247, 250, 0.65);
+}
+
+.game-ui {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel {
+  background: var(--panel-bg);
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.panel h2 {
+  font-size: 1.1rem;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.5rem;
+}
+
+.inventory,
+.log {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.inventory li,
+.log li {
+  padding: 0.35rem 0.5rem;
+  background: rgba(12, 16, 22, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 4px;
+}
+
+.log li {
+  font-size: 0.85rem;
+  color: rgba(245, 247, 250, 0.85);
+}
+
+@media (max-width: 960px) {
+  .game-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .game-ui {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .panel {
+    flex: 1 1 240px;
+  }
+}


### PR DESCRIPTION
## Summary
- update shared navigation on informational pages so the Game tab routes to the `/game/` prototype directory
- clarify the README instructions to visit `/game/` when launching the in-browser prototype

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4bee8d9ec832bb05b528c0511b864