### PR TITLE
Link Game tab to external repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pazneria.github.io
 
-This repository contains the static files for the **Pazneria** website. It is a simple static site composed of HTML, CSS and JavaScript.
+This repository contains the static files for the **Pazneria** website. It hosts the marketing pages and other standalone experiments as pure HTML, CSS, and JavaScript.
 
-The site hosts various small projects and experiments. Notably, under `game/` lives a canvas-based RPG written in JavaScript. You can open `game.html` to play the game directly in your browser.
+The playable OSRS-inspired prototype lives in its own repository, [`game`](https://github.com/pazneria/game). The navigation on this site simply links to the published build at <https://pazneria.github.io/game/>, keeping the codebases independent.
 
-Previous experiments, such as the early *Dataforge* idle game, have since been removed to keep the repository focused on the current content.
+To preview the site locally, open the HTML files in a browser or use any static web server to serve the repository root.

--- a/about.html
+++ b/about.html
@@ -22,7 +22,7 @@
       <ul class="nav-list">
         <li><a href="index.html" class="nav-link">Home</a></li>
         <li><a href="agi.html" class="nav-link">AGI Forecasting</a></li>
-        <li><a href="game.html" class="nav-link">Game</a></li>
+        <li><a href="https://pazneria.github.io/game/" class="nav-link">Game</a></li>
         <li><a href="about.html" class="nav-link">About</a></li>
         <li><a href="contact.html" class="nav-link">Contact</a></li>
       </ul>

--- a/contact.html
+++ b/contact.html
@@ -21,7 +21,7 @@
       <ul class="nav-list">
         <li><a href="index.html" class="nav-link">Home</a></li>
         <li><a href="agi.html" class="nav-link">AGI Forecasting</a></li>
-        <li><a href="game.html" class="nav-link">Game</a></li>
+        <li><a href="https://pazneria.github.io/game/" class="nav-link">Game</a></li>
         <li><a href="about.html" class="nav-link">About</a></li>
         <li><a href="contact.html" class="nav-link">Contact</a></li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -21,8 +21,8 @@ To add new sections, simply create another HTML file in the root directory (or a
       <a href="index.html" class="logo">Pazneria</a>
       <ul class="nav-list">
         <li><a href="index.html" class="nav-link">Home</a></li>
-        <li><a href=agi//" class="nav-link">AGI Timeline</a></li>
-        <li><a href="game/" class="nav-link">Game</a></li>
+        <li><a href="agi.html" class="nav-link">AGI Timeline</a></li>
+        <li><a href="https://pazneria.github.io/game/" class="nav-link">Game</a></li>
         <li><a href="about.html" class="nav-link">About</a></li>
         <li><a href="contact.html" class="nav-link">Contact</a></li>
       </ul>


### PR DESCRIPTION
## Summary
- remove the embedded `game/` directory so the user site no longer bundles the prototype code
- update the shared navigation and README to point to the standalone `pazneria/game` repository for the playable build

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4bee8d9ec832bb05b528c0511b864