### PR TITLE
Center navigation cards vertically

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -75,9 +75,11 @@ header {
 }
 
 .nav-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   gap: clamp(1.5rem, 4vw, 2.5rem);
+  width: 100%;
 }
 
 .section-card {
@@ -92,6 +94,7 @@ header {
   gap: 1.25rem;
   transition: transform var(--transition), box-shadow var(--transition),
     border-color var(--transition);
+  width: min(420px, 100%);
 }
 
 .section-card::after {


### PR DESCRIPTION
## Summary
- stack the navigation section cards vertically and center them on the page
- constrain card width so the centered layout has consistent sizing

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_69058532f7f0832b815b83f38272f282